### PR TITLE
Move extractGeocodeOptions to own file

### DIFF
--- a/api/csv/__tests__/index.js
+++ b/api/csv/__tests__/index.js
@@ -1,64 +1,6 @@
-/* eslint-disable camelcase */
 import test from 'ava'
 
-import {extractGeocodeOptions, ensureArray, extractIndexes} from '../index.js'
-
-test('extractGeocodeOptions / geocode options', t => {
-  const req = {
-    body: {
-      columns: ['col1', 'col2'],
-      citycode: '75001',
-      postcode: '75001',
-      type: 'address',
-      lon: 'longitude',
-      lat: 'latitude',
-      result_columns: ['result_col1', 'result_col2']
-    },
-    columnsInFile: ['col1', 'col2', 'col3']
-  }
-
-  const expected = {
-    columns: ['col1', 'col2'],
-    citycode: '75001',
-    postcode: '75001',
-    type: 'address',
-    lon: 'longitude',
-    lat: 'latitude',
-    resultColumns: ['result_col1', 'result_col2'],
-    indexes: ['address']
-  }
-
-  const actual = extractGeocodeOptions(req)
-  t.deepEqual(actual, expected)
-})
-
-test('extractGeocodeOptions / unknown column name', t => {
-  const req = {
-    body: {
-      columns: ['col1', 'unknown_col']
-    },
-    columnsInFile: ['col1', 'col2', 'col3']
-  }
-
-  const error = t.throws(() => extractGeocodeOptions(req))
-  t.is(error.status, 400)
-  t.is(error.message, 'At least one given column name is unknown')
-})
-
-test('extractGeocodeOptions / default columns', t => {
-  const req = {
-    body: {},
-    columnsInFile: ['col1', 'col2', 'col3']
-  }
-
-  const expected = {
-    columns: ['col1', 'col2', 'col3'],
-    indexes: ['address']
-  }
-
-  const actual = extractGeocodeOptions(req)
-  t.deepEqual(actual, expected)
-})
+import {ensureArray, extractIndexes} from '../index.js'
 
 test('ensureArray', t => {
   t.deepEqual(ensureArray('value'), ['value'])

--- a/api/csv/index.js
+++ b/api/csv/index.js
@@ -16,6 +16,7 @@ import batch from '../operations/batch.js'
 
 import {computeOutputFilename} from '../../batch/util/filename.js'
 import {createGeocodeStream} from '../../batch/stream/index.js'
+import {extractGeocodeOptions} from '../../batch/options.js'
 
 export {parseAndValidate} from './parse.js'
 
@@ -35,7 +36,7 @@ export function csv({operation, indexes}) {
     })
 
     const geocodeOptions = {
-      ...extractGeocodeOptions(req),
+      ...extractGeocodeOptions(req.body, {columnsInFile: req.columnsInFile}),
       operation
     }
 
@@ -77,80 +78,6 @@ export function extractIndexes(indexesValue) {
 
   // Remove duplicates
   return [...new Set(indexesValue)]
-}
-
-export function extractGeocodeOptions(req) {
-  const geocodeOptions = {}
-
-  if (req.body.columns) {
-    geocodeOptions.columns = ensureArray(req.body.columns)
-
-    if (geocodeOptions.columns.some(c => !req.columnsInFile.includes(c))) {
-      throw createHttpError(400, 'At least one given column name is unknown')
-    }
-  } else {
-    geocodeOptions.columns = req.columnsInFile
-  }
-
-  if (req.body.citycode) {
-    geocodeOptions.citycode = req.body.citycode
-  }
-
-  if (req.body.postcode) {
-    geocodeOptions.postcode = req.body.postcode
-  }
-
-  if (req.body.type) {
-    geocodeOptions.type = req.body.type
-  }
-
-  if (req.body.category) {
-    geocodeOptions.category = req.body.category
-  }
-
-  if (req.body.departmentcode) {
-    geocodeOptions.departmentcode = req.body.departmentcode
-  }
-
-  if (req.body.municipalitycode) {
-    geocodeOptions.municipalitycode = req.body.municipalitycode
-  }
-
-  if (req.body.oldmunicipalitycode) {
-    geocodeOptions.oldmunicipalitycode = req.body.oldmunicipalitycode
-  }
-
-  if (req.body.districtcode) {
-    geocodeOptions.districtcode = req.body.districtcode
-  }
-
-  if (req.body.section) {
-    geocodeOptions.section = req.body.section
-  }
-
-  if (req.body.sheet) {
-    geocodeOptions.sheet = req.body.sheet
-  }
-
-  if (req.body.number) {
-    geocodeOptions.number = req.body.number
-  }
-
-  if (req.body.lon) {
-    geocodeOptions.lon = req.body.lon
-  }
-
-  if (req.body.lat) {
-    geocodeOptions.lat = req.body.lat
-  }
-
-  if (req.body.result_columns) {
-    geocodeOptions.resultColumns = ensureArray(req.body.result_columns)
-  }
-
-  geocodeOptions.indexes = extractIndexes(req.body.indexes)
-
-  return geocodeOptions
 }
 
 export function ensureArray(value) {

--- a/batch/__tests__/options.js
+++ b/batch/__tests__/options.js
@@ -1,0 +1,61 @@
+/* eslint-disable camelcase */
+import test from 'ava'
+
+import {extractGeocodeOptions} from '../options.js'
+
+test('extractGeocodeOptions / geocode options', t => {
+  const req = {
+    body: {
+      columns: ['col1', 'col2'],
+      citycode: '75001',
+      postcode: '75001',
+      type: 'address',
+      lon: 'longitude',
+      lat: 'latitude',
+      result_columns: ['result_col1', 'result_col2']
+    },
+    columnsInFile: ['col1', 'col2', 'col3']
+  }
+
+  const expected = {
+    columns: ['col1', 'col2'],
+    citycode: '75001',
+    postcode: '75001',
+    type: 'address',
+    lon: 'longitude',
+    lat: 'latitude',
+    resultColumns: ['result_col1', 'result_col2'],
+    indexes: ['address']
+  }
+
+  const actual = extractGeocodeOptions(req)
+  t.deepEqual(actual, expected)
+})
+
+test('extractGeocodeOptions / unknown column name', t => {
+  const req = {
+    body: {
+      columns: ['col1', 'unknown_col']
+    },
+    columnsInFile: ['col1', 'col2', 'col3']
+  }
+
+  const error = t.throws(() => extractGeocodeOptions(req))
+  t.is(error.status, 400)
+  t.is(error.message, 'At least one given column name is unknown')
+})
+
+test('extractGeocodeOptions / default columns', t => {
+  const req = {
+    body: {},
+    columnsInFile: ['col1', 'col2', 'col3']
+  }
+
+  const expected = {
+    columns: ['col1', 'col2', 'col3'],
+    indexes: ['address']
+  }
+
+  const actual = extractGeocodeOptions(req)
+  t.deepEqual(actual, expected)
+})

--- a/batch/options.js
+++ b/batch/options.js
@@ -1,0 +1,76 @@
+import createHttpError from 'http-errors'
+import {ensureArray, extractIndexes} from '../api/csv/index.js'
+
+export function extractGeocodeOptions(body, {columnsInFile}) {
+  const geocodeOptions = {}
+
+  if (body.columns) {
+    geocodeOptions.columns = ensureArray(body.columns)
+
+    if (geocodeOptions.columns.some(c => !columnsInFile.includes(c))) {
+      throw createHttpError(400, 'At least one given column name is unknown')
+    }
+  } else {
+    geocodeOptions.columns = columnsInFile
+  }
+
+  if (body.citycode) {
+    geocodeOptions.citycode = body.citycode
+  }
+
+  if (body.postcode) {
+    geocodeOptions.postcode = body.postcode
+  }
+
+  if (body.type) {
+    geocodeOptions.type = body.type
+  }
+
+  if (body.category) {
+    geocodeOptions.category = body.category
+  }
+
+  if (body.departmentcode) {
+    geocodeOptions.departmentcode = body.departmentcode
+  }
+
+  if (body.municipalitycode) {
+    geocodeOptions.municipalitycode = body.municipalitycode
+  }
+
+  if (body.oldmunicipalitycode) {
+    geocodeOptions.oldmunicipalitycode = body.oldmunicipalitycode
+  }
+
+  if (body.districtcode) {
+    geocodeOptions.districtcode = body.districtcode
+  }
+
+  if (body.section) {
+    geocodeOptions.section = body.section
+  }
+
+  if (body.sheet) {
+    geocodeOptions.sheet = body.sheet
+  }
+
+  if (body.number) {
+    geocodeOptions.number = body.number
+  }
+
+  if (body.lon) {
+    geocodeOptions.lon = body.lon
+  }
+
+  if (body.lat) {
+    geocodeOptions.lat = body.lat
+  }
+
+  if (body.result_columns) {
+    geocodeOptions.resultColumns = ensureArray(body.result_columns)
+  }
+
+  geocodeOptions.indexes = extractIndexes(body.indexes)
+
+  return geocodeOptions
+}


### PR DESCRIPTION
This pull request moves the function `extractGeocodeOptions` to its own file `batch/options.js`